### PR TITLE
取得失敗したツイートの再取得

### DIFF
--- a/data/logger/logger.go
+++ b/data/logger/logger.go
@@ -39,16 +39,16 @@ func (mylogger *TRMLogger) Println(s string) {
 	log.Println(s)
 }
 
-func (mylogger *TRMLogger) Fatalln(e error) {
-	logf, err := os.OpenFile(mylogger.logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
-		fmt.Fprintf(os.Stdout, "error opening file: %v", err)
-	}
-	defer logf.Close()
-
-	log.SetOutput(logf)
-	log.Fatalln(e)
-}
+// func (mylogger *TRMLogger) Fatalln(e error) {
+// 	logf, err := os.OpenFile(mylogger.logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+// 	if err != nil {
+// 		fmt.Fprintf(os.Stdout, "error opening file: %v", err)
+// 	}
+// 	defer logf.Close()
+//
+// 	log.SetOutput(logf)
+// 	log.Fatalln(e)
+// }
 
 func (mylogger *TRMLogger) Printf(format string, e interface{}) {
 	logf, err := os.OpenFile(mylogger.logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)

--- a/data/main.go
+++ b/data/main.go
@@ -107,7 +107,8 @@ func retryGather(start int, channel string) {
 		tweet := twitter.Tweet{ItemID: itemID}
 		err := tweet.Fetch()
 		if err != nil {
-			if err.(*twitter.Error).Op == twitter.Op.Parse {
+			op := err.(*twitter.Error).Op
+			if op == twitter.Op.Parse || op == twitter.Op.Request {
 				slack.Post(channel, err.Error())
 			}
 			logger.Println("Could not fetch tweet:")


### PR DESCRIPTION
## How
### generating `failed_post_ids.tsv`

`stc_tweet_ids.post_id` カラムの中で `tweets.item_id` に値がないものを `failed_post_ids.tsv` に１行ずつ書き出し。

```
select ids.post_id into outfile 'failed_post_ids.tsv' from stc_tweet_ids as ids where ids.post_id not in ( select t.item_id from tweets as t );
```
### fetch retry and error notification

`failed_post_ids.tsv` から１行ずつ読み込みリトライ。

https://twitter.com にリダイレクトされる時とページが見つからない時以外をSlack通知。

```
op := err.(*twitter.Error).Op
if op == twitter.Op.Parse || op == twitter.Op.Request {
    slack.Post(channel, err.Error())
}
```
